### PR TITLE
Add tests and fix recipe attributes error.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,19 @@
-/.bundle/
+.vagrant
+# Bundler
+bin/*
+.bundle/*
+
+.kitchen/
+.kitchen.local.yml
+Berksfile.lock
+*~
+*#
+.#*
+\#*#
+.*.sw[a-z]
+*.un~
+/cookbooks
+/tmp
+/vendor
 /Gemfile.lock
-/vendor/
+

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,0 +1,16 @@
+---
+driver_plugin: vagrant
+driver_config:
+  require_chef_omnibus: true
+  
+platforms:
+- name: ubuntu-12.10
+  driver_config:
+    box: opscode-ubuntu-12.10
+    box_url: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_ubuntu-12.10_chef-provisionerless.box
+    
+
+suites:
+- name: default
+  run_list: ["recipe[doxygen::default]"]
+  attributes: {}

--- a/Berksfile
+++ b/Berksfile
@@ -1,0 +1,3 @@
+site :opscode
+
+metadata

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,19 @@
+source 'https://rubygems.org'
+
+gem 'berkshelf'
+gem 'chef-rewind'
+gem 'chef-sugar'
+
+group :test do
+  gem 'chef'
+  gem 'rspec'
+  gem 'chefspec'
+  gem 'guard'
+  gem 'guard-rspec'
+end
+
+group :integration do
+  gem 'test-kitchen'
+  gem 'serverspec'
+  gem 'kitchen-vagrant'
+end

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,2 +1,3 @@
-node.default[:doxygen][:options] = []
-node.default[:doxygen][:force_recompile] = false
+default['doxygen']['options'] = []
+default['doxygen']['force_recompile'] = false
+default['doxygen']['version'] = "1.8.6"

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -1,0 +1,18 @@
+require_relative 'spec_helper'
+
+describe 'doxygen::default' do
+  
+  let(:chef_run) do
+    ChefSpec::Runner.new do |node|
+    end.converge(described_recipe)
+  end
+
+  it 'should sync_git["/home/vagrant/doxygen"]' do
+    expect(chef_run).to sync_git("/home/vagrant/doxygen").with("user" => "vagrant", "checkout_branch" => chef_run.node['doxygen']['version'])
+  end
+
+  it 'syncing git[/home/vagrant/doxygen] should notify[bash[config_doxygen]] immediately' do
+    git_home_vagrant_doxygen = chef_run.find_resource "git", "/home/vagrant/doxygen"
+    expect(git_home_vagrant_doxygen).to notify('bash[config_doxygen]').to('run').immediately
+   end
+ end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,12 @@
+require 'chefspec'
+require 'chefspec/berkshelf'
+require 'chef/sugar'
+
+# fix guard safe_yml issues
+SafeYAML::OPTIONS[:default_mode] = :safe
+SafeYAML::OPTIONS[:deserialize_symbols] = true
+
+RSpec.configure do |config|
+  config.platform = 'ubuntu'
+  config.version = '12.04'
+end

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -1,0 +1,10 @@
+require 'serverspec'
+
+include Serverspec::Helper::Exec
+include Serverspec::Helper::DetectOS
+
+describe 'doxygen::default' do
+  it 'should have doxygen installed' do
+    expect(command("doxygen --version | grep '1.8.6'")).to return_exit_status 0
+  end
+end


### PR DESCRIPTION
Add Chefspec tests.

[Chefspec](https://github.com/sethvargo/chefspec) is an rspec extension
for chef recipe unit testing.

It allows you to develop the cookbook in a TDD manner, and without having to
run `vagrant up` to see recipe compilation issues.

Add TestKitchen Serverspec tests

[TestKitchen](http://kitchen.ci/) Allows you to write integration tests
so that you can verify your install on a number of different platforms.

[Serverspec](http://serverspec.org/) provides integration test resources
in an rspec syntax.
